### PR TITLE
added RSP admin training link

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,6 +19,7 @@ Pull requests welcome! Or add an issue, or tweet
 - [Data Science in the Tidyverse](https://github.com/AmeliaMN/data-science-in-tidyverse.git)
 - Deep learning with R (Tensorflow) [day 1](https://github.com/Scavetta/conf_tensorflow_training_day1) and [day 2](https://github.com/rstudio/conf_tensorflow_training_day2)
 - [Introduction to Shiny and R Markdown workshop](https://github.com/dtkaplan/shinymark)
+- [Rstudio Pro Products Admin Training](https://colorado.rstudio.com/rsc/pro-admin-training/overview/Overview.html)
 - [Shiny in Production](https://github.com/kellobri/shiny-prod-book)
 - [Train-the-trainer workshop](https://github.com/rstudio-education/teaching-workshop-2019-01)
 - [What they forgot to teach you about R](https://jennybc.github.io/wtf-2019-rsc/)


### PR DESCRIPTION
I don't know if they wanted these slide decks for the pre-conference workshop on administration of RStudio products posted, but if they did, here's the linkage.